### PR TITLE
Drop unused ffmpeg avresample requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ may or may not work; versions noted here are the only ones tested.
 
 ```
 sudo apt-get install libsdl2-dev libavcodec-dev libavdevice-dev libavfilter-dev \
-libavformat-dev libavresample-dev libavutil-dev libswresample-dev libswscale-dev \
+libavformat-dev libavutil-dev libswresample-dev libswscale-dev \
 libpostproc-dev libass-dev
 ```
 

--- a/cmake/Findffmpeg.cmake
+++ b/cmake/Findffmpeg.cmake
@@ -22,7 +22,6 @@ set(FFMPEG_COMPONENTS
     avformat
     avdevice
     avfilter
-    avresample
     avutil
     swresample
     swscale


### PR DESCRIPTION
See: https://bugs.debian.org/971321