### PR TITLE
Add aspect ratio to Kit_OutputFormat

### DIFF
--- a/include/kitchensink/kitformat.h
+++ b/include/kitchensink/kitformat.h
@@ -17,13 +17,15 @@ extern "C" {
  * @brief Contains information about the data format coming out from the player
  */
 typedef struct Kit_OutputFormat {
-    unsigned int format; ///< SDL Format (SDL_PixelFormat if video/subtitle, SDL_AudioFormat if audio)
-    int is_signed;       ///< Signedness, 1 = signed, 0 = unsigned (if audio)
-    int bytes;           ///< Bytes per sample per channel (if audio)
-    int samplerate;      ///< Sampling rate (if audio)
-    int channels;        ///< Channels (if audio)
-    int width;           ///< Width in pixels (if video)
-    int height;          ///< Height in pixels (if video)
+    unsigned int format;  ///< SDL Format (SDL_PixelFormat if video/subtitle, SDL_AudioFormat if audio)
+    int is_signed;        ///< Signedness, 1 = signed, 0 = unsigned (if audio)
+    int bytes;            ///< Bytes per sample per channel (if audio)
+    int samplerate;       ///< Sampling rate (if audio)
+    int channels;         ///< Channels (if audio)
+    int width;            ///< Width in pixels (if video)
+    int height;           ///< Height in pixels (if video)
+    int aspect_ratio_num; ///< Aspect ratio numerator (if video)
+    int aspect_ratio_den; ///< Aspect ratio denominator (if video)
 } Kit_OutputFormat;
 
 #ifdef __cplusplus

--- a/src/internal/video/kitvideo.c
+++ b/src/internal/video/kitvideo.c
@@ -203,6 +203,8 @@ Kit_Decoder* Kit_CreateVideoDecoder(const Kit_Source *src, int stream_index) {
     memset(&output, 0, sizeof(Kit_OutputFormat));
     output.width = dec->codec_ctx->width;
     output.height = dec->codec_ctx->height;
+    output.aspect_ratio_num = dec->codec_ctx->sample_aspect_ratio.num;
+    output.aspect_ratio_den = dec->codec_ctx->sample_aspect_ratio.den;
     output.format = _FindSDLPixelFormat(output_format);
 
     // Create scaler for handling format changes


### PR DESCRIPTION
We have an app that needs to know the video's aspect ratio. 

This PR adds the aspect ratio information from the `codec_ctx->sample_aspect_ratio` to the `Kit_OutputFormat` structure.

Maybe others would find it useful too.