### PR TITLE
Report EndOfFile when RWops runs out of bytes

### DIFF
--- a/src/kitsource.c
+++ b/src/kitsource.c
@@ -110,7 +110,7 @@ EXIT_0:
 }
 
 static int _RWReadCallback(void *userdata, uint8_t *buf, int size) {
-    int bytes_read = SDL_RWread((SDL_RWops*)userdata, buf, 1, size);
+    size_t bytes_read = SDL_RWread((SDL_RWops*)userdata, buf, 1, size);
     return bytes_read == 0 ? AVERROR_EOF : bytes_read;
 }
 

--- a/src/kitsource.c
+++ b/src/kitsource.c
@@ -110,7 +110,8 @@ EXIT_0:
 }
 
 static int _RWReadCallback(void *userdata, uint8_t *buf, int size) {
-    return SDL_RWread((SDL_RWops*)userdata, buf, 1, size);
+    int bytes_read = SDL_RWread((SDL_RWops*)userdata, buf, 1, size);
+    return bytes_read == 0 ? AVERROR_EOF : bytes_read;
 }
 
 static int64_t _RWGetSize(SDL_RWops *rw_ops) {


### PR DESCRIPTION
Bumped into this today, without this I was infinitely looping inside of FFMpeg, thankfully I had tried to write an exceedingly simple version of this library before trying Kitchensink out and bumped into the same thing earlier today. (Kitchensink is infinitely better, thank you for your work!)