### PR TITLE
Undef min/max due to msvc defining them in stdlib.h for C.

### DIFF
--- a/src/internal/subtitle/kitatlas.c
+++ b/src/internal/subtitle/kitatlas.c
@@ -2,9 +2,7 @@
 
 #include "kitchensink/internal/subtitle/kitatlas.h"
 
-#undef min
-
-static int min(int a, int b) {
+static int Kit_min(int a, int b) {
     if(a < b)
         return a;
     return b;
@@ -140,7 +138,7 @@ int Kit_GetAtlasItems(const Kit_TextureAtlas *atlas, SDL_Rect *sources, SDL_Rect
     assert(limit >= 0);
     const Kit_TextureAtlasItem *item = NULL;
 
-    int max_count = min(atlas->cur_items, limit);
+    int max_count = Kit_min(atlas->cur_items, limit);
     for(int i = 0; i < max_count; i++) {
         item = &atlas->items[i];
         if(sources != NULL)

--- a/src/internal/subtitle/kitatlas.c
+++ b/src/internal/subtitle/kitatlas.c
@@ -2,6 +2,8 @@
 
 #include "kitchensink/internal/subtitle/kitatlas.h"
 
+#undef min
+
 static int min(int a, int b) {
     if(a < b)
         return a;

--- a/src/kitlib.c
+++ b/src/kitlib.c
@@ -11,6 +11,9 @@
 
 static void _libass_msg_callback(int level, const char *fmt, va_list va, void *data) {}
 
+#undef min
+#undef max
+
 static int max(int a, int b) { return a > b ? a : b; }
 static int min(int a, int b) { return a < b ? a : b; }
 

--- a/src/kitlib.c
+++ b/src/kitlib.c
@@ -11,11 +11,8 @@
 
 static void _libass_msg_callback(int level, const char *fmt, va_list va, void *data) {}
 
-#undef min
-#undef max
-
-static int max(int a, int b) { return a > b ? a : b; }
-static int min(int a, int b) { return a < b ? a : b; }
+static int Kit_max(int a, int b) { return a > b ? a : b; }
+static int Kit_min(int a, int b) { return a < b ? a : b; }
 
 int Kit_InitASS(Kit_LibraryState *state) {
 #ifdef USE_DYNAMIC_LIBASS
@@ -93,19 +90,19 @@ void Kit_SetHint(Kit_HintType type, int value) {
     Kit_LibraryState *state = Kit_GetLibraryState();
     switch(type) {
         case KIT_HINT_THREAD_COUNT:
-            state->thread_count =  max(value, 0);
+            state->thread_count =  Kit_max(value, 0);
             break;
         case KIT_HINT_FONT_HINTING:
-            state->font_hinting = max(min(value, KIT_FONT_HINTING_COUNT), 0);
+            state->font_hinting = Kit_max(Kit_min(value, KIT_FONT_HINTING_COUNT), 0);
             break;
         case KIT_HINT_VIDEO_BUFFER_FRAMES:
-            state->video_buf_frames = max(value, 1);
+            state->video_buf_frames = Kit_max(value, 1);
             break;
         case KIT_HINT_AUDIO_BUFFER_FRAMES:
-            state->audio_buf_frames = max(value, 1);
+            state->audio_buf_frames = Kit_max(value, 1);
             break;
         case KIT_HINT_SUBTITLE_BUFFER_FRAMES:
-            state->subtitle_buf_frames = max(value, 1);
+            state->subtitle_buf_frames = Kit_max(value, 1);
             break;
     }
 }


### PR DESCRIPTION
There may be a better solution here, and I might be missing something myself, but when I tried to compile this under MSVC I immediately ran into this.  I was aware of `windows.h` defining minmax, but not of stdlib.h (specifically when compiling as C, a C++ source file wouldn't bump into this), and there seems to be no escape hatch as far as I can tell.