### PR TITLE
Improve support for janky input streams on the simple example

### DIFF
--- a/examples/example_simple.c
+++ b/examples/example_simple.c
@@ -60,6 +60,8 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
+    Kit_SetHint(KIT_HINT_VIDEO_BUFFER_PACKETS, 128);
+
     // Open up the sourcefile.
     // This can be a local file, network url, ...
     src = Kit_CreateSourceFromUrl(filename);

--- a/examples/example_simple.c
+++ b/examples/example_simple.c
@@ -161,13 +161,11 @@ int main(int argc, char *argv[]) {
         if(queued < AUDIO_BUFFER_SIZE) {
             int need = AUDIO_BUFFER_SIZE - queued;
 
-            while(need > 0) {
+            if(need > 0) {
                 ret = Kit_GetPlayerAudioData(player, queued, (unsigned char *)audio_buf, AUDIO_BUFFER_SIZE);
                 need -= ret;
                 if(ret > 0) {
                     SDL_QueueAudio(audio_dev, audio_buf, ret);
-                } else {
-                    break;
                 }
             }
             // If we now have data, start playback (again)


### PR DESCRIPTION
This change has been tested on live TV streams where seeking is not possible and the input stream may suffer from jitter. I also bumped KIT_HINT_VIDEO_BUFFER_PACKETS to support the streams I have been testing with (particularity 720p h264 streams with a frame rate of 50fps). Furthermore, I addressed an issue where audio and video would be slightly out of sync (by queuing smaller chunks of audio in each event loop).

The same adjustments are also applicable to the complex example, but perhaps it can be integrated with the library somehow instead?