### PR TITLE
Subtitle API improvements

### DIFF
--- a/examples/example_complex.c
+++ b/examples/example_complex.c
@@ -299,8 +299,8 @@ int main(int argc, char *argv[]) {
 
     // Playback temporary data buffers
     char audio_buf[AUDIO_BUFFER_SIZE];
-    SDL_Rect sources[ATLAS_MAX];
-    SDL_Rect targets[ATLAS_MAX];
+    SDL_FRect sources[ATLAS_MAX];
+    SDL_FRect targets[ATLAS_MAX];
     int mouse_x = 0;
     int mouse_y = 0;
     int size_w = 0;
@@ -470,10 +470,7 @@ int main(int argc, char *argv[]) {
             if(subtitle_tex != NULL) {
                 const int got = Kit_GetPlayerSubtitleSDLTexture(player, subtitle_tex, sources, targets, ATLAS_MAX);
                 for(int i = 0; i < got; i++) {
-                    SDL_FRect src_rect, dst_rect;
-                    SDL_RectToFRect(&sources[i], &src_rect);
-                    SDL_RectToFRect(&targets[i], &dst_rect);
-                    SDL_RenderTexture(renderer, subtitle_tex, &src_rect, &dst_rect);
+                    SDL_RenderTexture(renderer, subtitle_tex, &sources[i], &targets[i]);
                 }
             }
         }

--- a/examples/example_custom.c
+++ b/examples/example_custom.c
@@ -174,8 +174,8 @@ int main(int argc, char *argv[]) {
 
     // Playback temporary data buffers
     char audio_buf[AUDIO_BUFFER_SIZE];
-    SDL_Rect sources[ATLAS_MAX];
-    SDL_Rect targets[ATLAS_MAX];
+    SDL_FRect sources[ATLAS_MAX];
+    SDL_FRect targets[ATLAS_MAX];
 
     // Get movie area size
     SDL_SetRenderLogicalPresentation(
@@ -227,10 +227,7 @@ int main(int argc, char *argv[]) {
         // For subtitles, use screen size instead of video size for best quality
         const int got = Kit_GetPlayerSubtitleSDLTexture(player, subtitle_tex, sources, targets, ATLAS_MAX);
         for(int i = 0; i < got; i++) {
-            SDL_FRect src_rect, dst_rect;
-            SDL_RectToFRect(&sources[i], &src_rect);
-            SDL_RectToFRect(&targets[i], &dst_rect);
-            SDL_RenderTexture(renderer, subtitle_tex, &src_rect, &dst_rect);
+            SDL_RenderTexture(renderer, subtitle_tex, &sources[i], &targets[i]);
         }
 
         // Render to screen + wait for vsync

--- a/examples/example_rwops.c
+++ b/examples/example_rwops.c
@@ -122,8 +122,8 @@ int main(int argc, char *argv[]) {
 
     // Playback temporary data buffers
     char audio_buf[AUDIO_BUFFER_SIZE];
-    SDL_Rect sources[ATLAS_MAX];
-    SDL_Rect targets[ATLAS_MAX];
+    SDL_FRect sources[ATLAS_MAX];
+    SDL_FRect targets[ATLAS_MAX];
 
     // Get movie area size
     SDL_SetRenderLogicalPresentation(
@@ -175,10 +175,7 @@ int main(int argc, char *argv[]) {
         // For subtitles, use screen size instead of video size for best quality
         const int got = Kit_GetPlayerSubtitleSDLTexture(player, subtitle_tex, sources, targets, ATLAS_MAX);
         for(int i = 0; i < got; i++) {
-            SDL_FRect src_rect, dst_rect;
-            SDL_RectToFRect(&sources[i], &src_rect);
-            SDL_RectToFRect(&targets[i], &dst_rect);
-            SDL_RenderTexture(renderer, subtitle_tex, &src_rect, &dst_rect);
+            SDL_RenderTexture(renderer, subtitle_tex, &sources[i], &targets[i]);
         }
 
         // Render to screen + wait for vsync

--- a/examples/example_simple.c
+++ b/examples/example_simple.c
@@ -107,8 +107,8 @@ int main(int argc, char *argv[]) {
 
     // Playback temporary data buffers
     char audio_buf[AUDIO_BUFFER_SIZE];
-    SDL_Rect sources[ATLAS_MAX];
-    SDL_Rect targets[ATLAS_MAX];
+    SDL_FRect sources[ATLAS_MAX];
+    SDL_FRect targets[ATLAS_MAX];
 
     // Get movie area size
     SDL_SetRenderLogicalPresentation(
@@ -155,10 +155,7 @@ int main(int argc, char *argv[]) {
         if(subtitle_tex != NULL) {
             const int got = Kit_GetPlayerSubtitleSDLTexture(player, subtitle_tex, sources, targets, ATLAS_MAX);
             for(int i = 0; i < got; i++) {
-                SDL_FRect src_rect, dst_rect;
-                SDL_RectToFRect(&sources[i], &src_rect);
-                SDL_RectToFRect(&targets[i], &dst_rect);
-                SDL_RenderTexture(renderer, subtitle_tex, &src_rect, &dst_rect);
+                SDL_RenderTexture(renderer, subtitle_tex, &sources[i], &targets[i]);
             }
         }
 

--- a/include/kitchensink3/internal/subtitle/kitatlas.h
+++ b/include/kitchensink3/internal/subtitle/kitatlas.h
@@ -20,8 +20,8 @@
  * and where it should be drawn on the output surface (target).
  */
 typedef struct Kit_TextureAtlasItem {
-    SDL_Rect source; //< Source coordinates on cache surface
-    SDL_Rect target; //< Target coordinates on output surface
+    SDL_Rect source;  //< Source coordinates on cache surface
+    SDL_FRect target; //< Target coordinates on output surface
 } Kit_TextureAtlasItem;
 
 /**
@@ -86,7 +86,7 @@ KIT_LOCAL void Kit_CheckAtlasTextureSize(Kit_TextureAtlas *atlas, SDL_Texture *t
  * @param limit maximum number of items to copy
  * @return number of items actually copied (min of current item count and limit)
  */
-KIT_LOCAL int Kit_GetAtlasItems(const Kit_TextureAtlas *atlas, SDL_Rect *sources, SDL_Rect *targets, int limit);
+KIT_LOCAL int Kit_GetAtlasItems(const Kit_TextureAtlas *atlas, SDL_FRect *sources, SDL_FRect *targets, int limit);
 
 /**
  * @brief Packs a surface into the atlas: finds free space, uploads the surface pixels into
@@ -100,6 +100,6 @@ KIT_LOCAL int Kit_GetAtlasItems(const Kit_TextureAtlas *atlas, SDL_Rect *sources
  * @return 0 on success, -1 if the atlas is full or no free slot could be found for the surface
  */
 KIT_LOCAL int
-Kit_AddAtlasItem(Kit_TextureAtlas *atlas, SDL_Texture *texture, const SDL_Surface *surface, const SDL_Rect *target);
+Kit_AddAtlasItem(Kit_TextureAtlas *atlas, SDL_Texture *texture, const SDL_Surface *surface, const SDL_FRect *target);
 
 #endif // KITATLAS_H

--- a/include/kitchensink3/internal/subtitle/kitsubtitle.h
+++ b/include/kitchensink3/internal/subtitle/kitsubtitle.h
@@ -82,7 +82,7 @@ KIT_LOCAL void Kit_SetSubtitleDecoderSize(const Kit_Decoder *dec, int w, int h);
  * @return number of items actually copied
  */
 KIT_LOCAL int
-Kit_GetSubtitleDecoderSDLTextureInfo(const Kit_Decoder *dec, SDL_Rect *sources, SDL_Rect *targets, int limit);
+Kit_GetSubtitleDecoderSDLTextureInfo(const Kit_Decoder *dec, SDL_FRect *sources, SDL_FRect *targets, int limit);
 
 /**
  * @brief Retrieves the subtitle output pixel format.

--- a/include/kitchensink3/kitplayer.h
+++ b/include/kitchensink3/kitplayer.h
@@ -510,14 +510,11 @@ Kit_CreatePlayerSubtitleSDLTexture(const Kit_Player *player, SDL_Renderer *rende
  *
  * For example:
  * ```
- * SDL_Rect sources[256];
- * SDL_Rect targets[256];
+ * SDL_FRect sources[256];
+ * SDL_FRect targets[256];
  * int got = Kit_GetPlayerSubtitleSDLTexture(player, subtitle_tex, sources, targets, 256);
  * for(int i = 0; i < got; i++) {
- *     SDL_FRect src_rect, dst_rect;
- *     SDL_RectToFRect(&sources[i], &src_rect);
- *     SDL_RectToFRect(&targets[i], &dst_rect);
- *     SDL_RenderTexture(renderer, subtitle_tex, &src_rect, &dst_rect);
+ *     SDL_RenderTexture(renderer, subtitle_tex, &sources[i], &targets[i]);
  * }
  * ```
  *
@@ -529,7 +526,7 @@ Kit_CreatePlayerSubtitleSDLTexture(const Kit_Player *player, SDL_Renderer *rende
  * @return Number of subtitle rectangles to render (may be 0)
  */
 KIT_API int Kit_GetPlayerSubtitleSDLTexture(
-    const Kit_Player *player, SDL_Texture *texture, SDL_Rect *sources, SDL_Rect *targets, int limit
+    const Kit_Player *player, SDL_Texture *texture, SDL_FRect *sources, SDL_FRect *targets, int limit
 );
 
 /**

--- a/src/internal/subtitle/kitatlas.c
+++ b/src/internal/subtitle/kitatlas.c
@@ -120,24 +120,24 @@ void Kit_CheckAtlasTextureSize(Kit_TextureAtlas *atlas, SDL_Texture *texture) {
     }
 }
 
-int Kit_GetAtlasItems(const Kit_TextureAtlas *atlas, SDL_Rect *sources, SDL_Rect *targets, int limit) {
+int Kit_GetAtlasItems(const Kit_TextureAtlas *atlas, SDL_FRect *sources, SDL_FRect *targets, int limit) {
     assert(atlas != NULL);
     assert(limit >= 0);
     const Kit_TextureAtlasItem *item = NULL;
 
-    int max_count = Kit_min(atlas->cur_items, limit);
+    const int max_count = Kit_min(atlas->cur_items, limit);
     for(int i = 0; i < max_count; i++) {
         item = &atlas->items[i];
         if(sources != NULL)
-            memcpy(&sources[i], &item->source, sizeof(SDL_Rect));
+            SDL_RectToFRect(&item->source, &sources[i]);
         if(targets != NULL)
-            memcpy(&targets[i], &item->target, sizeof(SDL_Rect));
+            targets[i] = item->target;
     }
     return max_count;
 }
 
 int Kit_AddAtlasItem(
-    Kit_TextureAtlas *atlas, SDL_Texture *texture, const SDL_Surface *surface, const SDL_Rect *target
+    Kit_TextureAtlas *atlas, SDL_Texture *texture, const SDL_Surface *surface, const SDL_FRect *target
 ) {
     assert(atlas != NULL);
     assert(surface != NULL);
@@ -148,9 +148,7 @@ int Kit_AddAtlasItem(
         return -1;
 
     // Create a new item
-    Kit_TextureAtlasItem item;
-    memset(&item, 0, sizeof(Kit_TextureAtlasItem));
-    memcpy(&item.target, target, sizeof(SDL_Rect));
+    Kit_TextureAtlasItem item = {.source = {0}, .target = *target};
 
     // Allocate space for the new item
     if(Kit_FindFreeAtlasSlot(atlas, surface, &item) != 0) {

--- a/src/internal/subtitle/kitsubtitle.c
+++ b/src/internal/subtitle/kitsubtitle.c
@@ -232,7 +232,7 @@ void Kit_GetSubtitleDecoderSDLTexture(const Kit_Decoder *dec, SDL_Texture *textu
     Kit_GetSubtitleRendererSDLTexture(subtitle_dec->renderer, subtitle_dec->atlas, texture, sync_ts);
 }
 
-int Kit_GetSubtitleDecoderSDLTextureInfo(const Kit_Decoder *dec, SDL_Rect *sources, SDL_Rect *targets, int limit) {
+int Kit_GetSubtitleDecoderSDLTextureInfo(const Kit_Decoder *dec, SDL_FRect *sources, SDL_FRect *targets, int limit) {
     const Kit_SubtitleDecoder *subtitle_dec = dec->userdata;
     return Kit_GetAtlasItems(subtitle_dec->atlas, sources, targets, limit);
 }

--- a/src/internal/subtitle/renderers/kitsubass.c
+++ b/src/internal/subtitle/renderers/kitsubass.c
@@ -119,7 +119,7 @@ static int ren_get_ass_data_cb(
         }
 
         Kit_ProcessAssImage(dst->pixels, src, dst->pitch);
-        SDL_Rect target;
+        SDL_FRect target;
         target.x = src->dst_x;
         target.y = src->dst_y;
         target.w = dst->w;

--- a/src/internal/subtitle/renderers/kitsubimage.c
+++ b/src/internal/subtitle/renderers/kitsubimage.c
@@ -76,7 +76,7 @@ static bool Kit_ProcessPacketToAtlas(
     if(image_renderer->out_packet->clear)
         Kit_ClearAtlasContent(atlas);
     if(image_renderer->out_packet->surface != NULL) {
-        SDL_Rect target;
+        SDL_FRect target;
         target.x = image_renderer->out_packet->x * image_renderer->scale_x;
         target.y = image_renderer->out_packet->y * image_renderer->scale_y;
         target.w = image_renderer->out_packet->surface->w * image_renderer->scale_x;

--- a/src/kitplayer.c
+++ b/src/kitplayer.c
@@ -575,7 +575,7 @@ int Kit_GetPlayerAudioData(
 }
 
 int Kit_GetPlayerSubtitleSDLTexture(
-    const Kit_Player *player, SDL_Texture *texture, SDL_Rect *sources, SDL_Rect *targets, int limit
+    const Kit_Player *player, SDL_Texture *texture, SDL_FRect *sources, SDL_FRect *targets, int limit
 ) {
     assert(player != NULL);
     assert(texture != NULL);

--- a/tests/common/kit_assert.h
+++ b/tests/common/kit_assert.h
@@ -35,13 +35,13 @@ assert_double_in_range_impl(const double value, const double min, const double m
  * (cmocka's assert_int_in_range only handles integers.) */
 #define assert_double_in_range(value, min, max) assert_double_in_range_impl((value), (min), (max), __FILE__, __LINE__)
 
-static inline void assert_rect_in_bounds_impl(
-    const SDL_Rect *rect, const int bound_w, const int bound_h, const char *file, const int line
+static inline void assert_frect_in_bounds_impl(
+    const SDL_FRect *rect, const float bound_w, const float bound_h, const char *file, const int line
 ) {
-    if(rect->x < 0 || rect->y < 0 || rect->w <= 0 || rect->h <= 0 || rect->x + rect->w > bound_w ||
+    if(rect->x < 0.0f || rect->y < 0.0f || rect->w <= 0.0f || rect->h <= 0.0f || rect->x + rect->w > bound_w ||
        rect->y + rect->h > bound_h) {
         cmocka_print_error(
-            "rect {x=%d, y=%d, w=%d, h=%d} not within %dx%d bounds\n",
+            "rect {x=%f, y=%f, w=%f, h=%f} not within %fx%f bounds\n",
             rect->x,
             rect->y,
             rect->w,
@@ -53,10 +53,10 @@ static inline void assert_rect_in_bounds_impl(
     }
 }
 
-/** @brief Asserts an SDL_Rect has a non-negative origin, a positive size, and lies fully inside a
+/** @brief Asserts an SDL_FRect has a non-negative origin, a positive size, and lies fully inside a
  * bound_w x bound_h area, reporting the offending rect on failure. */
-#define assert_rect_in_bounds(rect, bound_w, bound_h)                                                                 \
-    assert_rect_in_bounds_impl((rect), (bound_w), (bound_h), __FILE__, __LINE__)
+#define assert_frect_in_bounds(rect, bound_w, bound_h)                                                               \
+    assert_frect_in_bounds_impl((rect), (bound_w), (bound_h), __FILE__, __LINE__)
 
 static inline void assert_source_open_fails_cleanly_impl(const char *path, const char *file, const int line) {
     const char *printable_path = path != NULL ? path : "(null)";

--- a/tests/common/kit_playback.h
+++ b/tests/common/kit_playback.h
@@ -260,7 +260,7 @@ static inline bool drain_audio_to_eof(Kit_Player *player) {
  * returns the rect count (0 on timeout). Rendering is pull-driven off the player's sync clock, which only advances
  * while playback is pumped, so the video texture must be pumped alongside the subtitle getter. */
 static inline int pump_until_subtitle_rects(
-    Kit_Player *player, SDL_Texture *video_tex, SDL_Texture *sub_tex, SDL_Rect *sources, SDL_Rect *targets, int limit
+    Kit_Player *player, SDL_Texture *video_tex, SDL_Texture *sub_tex, SDL_FRect *sources, SDL_FRect *targets, int limit
 ) {
     const Uint64 wait_start = SDL_GetTicks();
     while(SDL_GetTicks() - wait_start < WAIT_BOUND_MS) {

--- a/tests/decoder/test_player.c
+++ b/tests/decoder/test_player.c
@@ -766,8 +766,8 @@ static void test_subtitle_texture_zero_limit(void **state) {
     Kit_PlayerPlay(ts->player);
 
     // Act / Assert: limit 0 must yield 0 rects.
-    SDL_Rect sources[4];
-    SDL_Rect targets[4];
+    SDL_FRect sources[4];
+    SDL_FRect targets[4];
     const int got = Kit_GetPlayerSubtitleSDLTexture(ts->player, ts->texture, sources, targets, 0);
     assert_int_equal(got, 0);
 

--- a/tests/decoder/test_player_stress.c
+++ b/tests/decoder/test_player_stress.c
@@ -266,8 +266,8 @@ static int audio_getter_thread(void *data) {
 /** @brief Worker: tight loop of Kit_GetPlayerSubtitleSDLTexture() until told to stop. */
 static int subtitle_getter_thread(void *data) {
     SubtitleWorkerCtx *ctx = data;
-    SDL_Rect sources[RECT_LIMIT];
-    SDL_Rect targets[RECT_LIMIT];
+    SDL_FRect sources[RECT_LIMIT];
+    SDL_FRect targets[RECT_LIMIT];
     long i;
     for(i = 0; i < WORKER_ITER_CAP && !SDL_GetAtomicInt(ctx->stop); i++) {
         Kit_GetPlayerSubtitleSDLTexture(ctx->player, ctx->sub_tex, sources, targets, RECT_LIMIT);

--- a/tests/decoder/test_stream_switch.c
+++ b/tests/decoder/test_stream_switch.c
@@ -309,8 +309,8 @@ static void test_close_subtitle_stream_mid_play(void **state) {
 
     // Act: pump until subtitle rects appear, confirming subtitles are
     // actually active before closing the stream.
-    SDL_Rect sources[16];
-    SDL_Rect targets[16];
+    SDL_FRect sources[16];
+    SDL_FRect targets[16];
     const int got = pump_until_subtitle_rects(ts->player, ts->video_tex, ts->sub_tex, sources, targets, 16);
     assert_true(got > 0);
 

--- a/tests/decoder/test_subtitle_render.c
+++ b/tests/decoder/test_subtitle_render.c
@@ -127,13 +127,14 @@ static int test_teardown(void **state) {
 }
 
 /** @brief Asserts a batch of rects has sources within the atlas bounds and targets with positive, sane sizes. */
-static void assert_rects_sane(const SDL_Rect *sources, const SDL_Rect *targets, int count) {
+static void assert_rects_sane(const SDL_FRect *sources, const SDL_FRect *targets, int count) {
     for(int i = 0; i < count; i++) {
-        assert_rect_in_bounds(&sources[i], ATLAS_SIZE, ATLAS_SIZE);
+        // Sources must be within the atlas bounds
+        assert_frect_in_bounds(&sources[i], (float)ATLAS_SIZE, (float)ATLAS_SIZE);
         // Targets may extend past the screen area, so only their sizes are
         // bounded (against garbage values, not any real layout limit).
-        assert_int_in_range(targets[i].w, 1, 10000);
-        assert_int_in_range(targets[i].h, 1, 10000);
+        assert_double_in_range(targets[i].w, 1, 10000);
+        assert_double_in_range(targets[i].h, 1, 10000);
     }
 }
 
@@ -147,8 +148,8 @@ static void test_srt_subtitle_renders(void **state) {
     open_subtitle_fixture(f, SRT_FILE);
 
     // Act
-    SDL_Rect sources[RECT_LIMIT];
-    SDL_Rect targets[RECT_LIMIT];
+    SDL_FRect sources[RECT_LIMIT];
+    SDL_FRect targets[RECT_LIMIT];
     const int got = pump_until_subtitle_rects(f->player, f->video_tex, f->sub_tex, sources, targets, RECT_LIMIT);
 
     // Assert
@@ -168,8 +169,8 @@ static void test_ass_subtitle_renders(void **state) {
     open_subtitle_fixture(f, ASS_FILE);
 
     // Act
-    SDL_Rect sources[RECT_LIMIT];
-    SDL_Rect targets[RECT_LIMIT];
+    SDL_FRect sources[RECT_LIMIT];
+    SDL_FRect targets[RECT_LIMIT];
     const int got = pump_until_subtitle_rects(f->player, f->video_tex, f->sub_tex, sources, targets, RECT_LIMIT);
 
     // Assert
@@ -190,8 +191,8 @@ static void test_image_subtitle_renders(void **state) {
     open_subtitle_fixture(f, IMAGE_FILE);
 
     // Act
-    SDL_Rect sources[RECT_LIMIT];
-    SDL_Rect targets[RECT_LIMIT];
+    SDL_FRect sources[RECT_LIMIT];
+    SDL_FRect targets[RECT_LIMIT];
     const int got = pump_until_subtitle_rects(f->player, f->video_tex, f->sub_tex, sources, targets, RECT_LIMIT);
 
     // Assert
@@ -211,8 +212,8 @@ static void test_image_subtitle_screen_resize(void **state) {
     // Arrange: get the cue on screen first.
     open_subtitle_fixture(f, IMAGE_FILE);
 
-    SDL_Rect sources[RECT_LIMIT];
-    SDL_Rect targets[RECT_LIMIT];
+    SDL_FRect sources[RECT_LIMIT];
+    SDL_FRect targets[RECT_LIMIT];
     const int got_before =
         pump_until_subtitle_rects(f->player, f->video_tex, f->sub_tex, sources, targets, RECT_LIMIT);
     assert_true(got_before > 0);
@@ -238,12 +239,12 @@ static void test_subtitle_screen_resize(void **state) {
     // Arrange: render one cue at the original screen size.
     open_subtitle_fixture(f, SRT_FILE);
 
-    SDL_Rect sources[RECT_LIMIT];
-    SDL_Rect targets[RECT_LIMIT];
+    SDL_FRect sources[RECT_LIMIT];
+    SDL_FRect targets[RECT_LIMIT];
     const int got_before =
         pump_until_subtitle_rects(f->player, f->video_tex, f->sub_tex, sources, targets, RECT_LIMIT);
     assert_true(got_before > 0);
-    const SDL_Rect target_before = targets[0];
+    const SDL_FRect target_before = targets[0];
 
     // Act
     Kit_SetPlayerScreenSize(f->player, SCREEN_W * 2, SCREEN_H * 2);
@@ -255,7 +256,7 @@ static void test_subtitle_screen_resize(void **state) {
     for(int i = 0; i < PUMP_ITERS && !changed; i++) {
         Kit_GetPlayerVideoSDLTexture(f->player, f->video_tex, NULL);
         const int got_after = Kit_GetPlayerSubtitleSDLTexture(f->player, f->sub_tex, sources, targets, RECT_LIMIT);
-        if(got_after > 0 && memcmp(&targets[0], &target_before, sizeof(SDL_Rect)) != 0)
+        if(got_after > 0 && memcmp(&targets[0], &target_before, sizeof(SDL_FRect)) != 0)
             changed = true;
         else
             SDL_Delay(PUMP_DELAY_MS);
@@ -314,8 +315,8 @@ static void test_font_attachment_subtitle(void **state) {
     open_subtitle_fixture(f, FONT_FILE);
 
     // Act
-    SDL_Rect sources[RECT_LIMIT];
-    SDL_Rect targets[RECT_LIMIT];
+    SDL_FRect sources[RECT_LIMIT];
+    SDL_FRect targets[RECT_LIMIT];
     const int got = pump_until_subtitle_rects(f->player, f->video_tex, f->sub_tex, sources, targets, RECT_LIMIT);
 
     // Assert

--- a/tests/unit/test_atlas.c
+++ b/tests/unit/test_atlas.c
@@ -145,19 +145,55 @@ static void test_add_and_get_items(void **state) {
     Kit_CheckAtlasTextureSize(ts->atlas, env->texture);
     ts->item = SDL_CreateSurface(16, 16, SDL_PIXELFORMAT_RGBA32);
     assert_non_null(ts->item);
-    const SDL_Rect target = {10, 10, 16, 16};
+    const SDL_FRect target = {10, 10, 16, 16};
 
     // Act
     assert_int_equal(Kit_AddAtlasItem(ts->atlas, env->texture, ts->item, &target), 0);
 
     // Assert: item was recorded and can be read back
     assert_int_equal(ts->atlas->cur_items, 1);
-    SDL_Rect sources[4], targets[4];
+    SDL_FRect sources[4], targets[4];
     assert_int_equal(Kit_GetAtlasItems(ts->atlas, sources, targets, 4), 1);
-    assert_int_equal(targets[0].x, 10);
-    assert_int_equal(targets[0].y, 10);
-    assert_int_equal(sources[0].w, 16);
-    assert_int_equal(sources[0].h, 16);
+    assert_float_equal(targets[0].x, 10.0f, 0.0);
+    assert_float_equal(targets[0].y, 10.0f, 0.0);
+    assert_float_equal(sources[0].w, 16.0f, 0.0);
+    assert_float_equal(sources[0].h, 16.0f, 0.0);
+
+    SDL_DestroySurface(ts->item);
+    ts->item = NULL;
+    Kit_FreeAtlas(ts->atlas);
+    ts->atlas = NULL;
+}
+
+/**
+ * @brief A fractional target rect survives the add/get round-trip unrounded, and the returned
+ * source rect equals the packed integer region converted to float — subpixel placement must not
+ * be truncated anywhere in the atlas.
+ */
+static void test_fractional_target_roundtrip(void **state) {
+    TestState *ts = *state;
+    atlas_env *env = ts->env;
+    // Arrange
+    ts->atlas = Kit_CreateAtlas();
+    Kit_CheckAtlasTextureSize(ts->atlas, env->texture);
+    ts->item = SDL_CreateSurface(16, 16, SDL_PIXELFORMAT_RGBA32);
+    assert_non_null(ts->item);
+    const SDL_FRect target = {10.5f, 20.25f, 16.75f, 8.5f};
+
+    // Act
+    assert_int_equal(Kit_AddAtlasItem(ts->atlas, env->texture, ts->item, &target), 0);
+
+    // Assert: target comes back bit-exact, source is the integer packed region as float
+    SDL_FRect sources[1], targets[1];
+    assert_int_equal(Kit_GetAtlasItems(ts->atlas, sources, targets, 1), 1);
+    assert_float_equal(targets[0].x, 10.5f, 0.0);
+    assert_float_equal(targets[0].y, 20.25f, 0.0);
+    assert_float_equal(targets[0].w, 16.75f, 0.0);
+    assert_float_equal(targets[0].h, 8.5f, 0.0);
+    assert_float_equal(sources[0].x, 0.0f, 0.0);
+    assert_float_equal(sources[0].y, 0.0f, 0.0);
+    assert_float_equal(sources[0].w, 16.0f, 0.0);
+    assert_float_equal(sources[0].h, 16.0f, 0.0);
 
     SDL_DestroySurface(ts->item);
     ts->item = NULL;
@@ -176,7 +212,7 @@ static void test_clear_resets_atlas(void **state) {
     Kit_CheckAtlasTextureSize(ts->atlas, env->texture);
     ts->item = SDL_CreateSurface(16, 16, SDL_PIXELFORMAT_RGBA32);
     assert_non_null(ts->item);
-    const SDL_Rect target = {10, 10, 16, 16};
+    const SDL_FRect target = {10, 10, 16, 16};
     assert_int_equal(Kit_AddAtlasItem(ts->atlas, env->texture, ts->item, &target), 0);
     assert_int_equal(ts->atlas->cur_items, 1);
 
@@ -197,6 +233,7 @@ int main(void) {
         cmocka_unit_test_setup_teardown(test_create_and_free, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_check_texture_size, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_add_and_get_items, test_setup, test_teardown),
+        cmocka_unit_test_setup_teardown(test_fractional_target_roundtrip, test_setup, test_teardown),
         cmocka_unit_test_setup_teardown(test_clear_resets_atlas, test_setup, test_teardown),
     };
     return cmocka_run_group_tests(tests, group_setup, group_teardown);


### PR DESCRIPTION
Now that we are using SDL3, we should use the FRect (float rectangle) type which the SDL3 renderer API also uses.